### PR TITLE
Use vkGetInstanceProcAddr to find wayland specific functions

### DIFF
--- a/main.c
+++ b/main.c
@@ -843,10 +843,10 @@ init_wayland(struct vkcube *vc)
 
    PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR get_wayland_presentation_support =
       (PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR)
-      vkGetDeviceProcAddr(vc->device, "vkGetPhysicalDeviceWaylandPresentationSupportKHR");
+      vkGetInstanceProcAddr(vc->instance, "vkGetPhysicalDeviceWaylandPresentationSupportKHR");
    PFN_vkCreateWaylandSurfaceKHR create_wayland_surface =
       (PFN_vkCreateWaylandSurfaceKHR)
-      vkGetDeviceProcAddr(vc->device, "vkCreateWaylandSurfaceKHR");
+      vkGetInstanceProcAddr(vc->instance, "vkCreateWaylandSurfaceKHR");
 
    if (!get_wayland_presentation_support(vc->physical_device, 0,
                                          vc->wl.display)) {

--- a/main.c
+++ b/main.c
@@ -82,8 +82,11 @@ init_vk(struct vkcube *vc, const char *extension)
             .pApplicationName = "vkcube",
             .apiVersion = VK_MAKE_VERSION(1, 0, 2),
          },
-         .enabledExtensionCount = (extension != NULL),
-         .ppEnabledExtensionNames = &extension,
+         .enabledExtensionCount = extension ? 2 : 0,
+         .ppEnabledExtensionNames = (const char *[2]) {
+            VK_KHR_SURFACE_EXTENSION_NAME,
+            extension,
+         },
       },
       NULL,
       &vc->instance);


### PR DESCRIPTION
According to the documentation of vkGetDeviceProcAddr [1], it may be
used only for functions that take a VkDevice or one of its child object
types as its first argument. The returned function calls directly into
the ICD, bypassing the object unwrapping done in the Vulkan loader
dispatch functions.
When linked against the Vulkan loader, vkEnumeratePhysicalDevices returns
wrapped vkPhysicalDevices, so this used to cause a segmentation fault
in vkGetPhysicalDeviceWaylandPresentationSupportKHR.

[1] https://www.khronos.org/registry/vulkan/specs/1.0/man/html/vkGetDeviceProcAddr.html
