### PR TITLE
main: make initialization work with LunarG's loader

### DIFF
--- a/main.c
+++ b/main.c
@@ -75,6 +75,11 @@ fail_if(int cond, const char *format, ...)
 static void
 init_vk(struct vkcube *vc, const char *extension)
 {
+   const char *extensions[2] = {
+      VK_KHR_SURFACE_EXTENSION_NAME,
+   };
+   extensions[1] = extension;
+
    vkCreateInstance(&(VkInstanceCreateInfo) {
          .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
          .pApplicationInfo = &(VkApplicationInfo) {
@@ -82,8 +87,8 @@ init_vk(struct vkcube *vc, const char *extension)
             .pApplicationName = "vkcube",
             .apiVersion = VK_MAKE_VERSION(1, 0, 2),
          },
-         .enabledExtensionCount = (extension != NULL),
-         .ppEnabledExtensionNames = &extension,
+         .enabledExtensionCount = (extensions[1] != NULL) ? 2 : 0,
+         .ppEnabledExtensionNames = extensions,
       },
       NULL,
       &vc->instance);
@@ -843,10 +848,10 @@ init_wayland(struct vkcube *vc)
 
    PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR get_wayland_presentation_support =
       (PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR)
-      vkGetDeviceProcAddr(vc->device, "vkGetPhysicalDeviceWaylandPresentationSupportKHR");
+      vkGetInstanceProcAddr(vc->instance, "vkGetPhysicalDeviceWaylandPresentationSupportKHR");
    PFN_vkCreateWaylandSurfaceKHR create_wayland_surface =
       (PFN_vkCreateWaylandSurfaceKHR)
-      vkGetDeviceProcAddr(vc->device, "vkCreateWaylandSurfaceKHR");
+      vkGetInstanceProcAddr(vc->instance, "vkCreateWaylandSurfaceKHR");
 
    if (!get_wayland_presentation_support(vc->physical_device, 0,
                                          vc->wl.display)) {


### PR DESCRIPTION
It seems we'll crash into the loader's trampoline if we don't query symbols
using the instance rather than the device.

Also wayland or xcb support symbols requires extensions related to surfaces
that imply VK_KHR_surface. The loader doesn't seem to understand the
dependency, therefore we might want to put VK_KHR_surface in the list of
extensions we need.
