### PR TITLE
Validation layer cleanups

### DIFF
--- a/common.h
+++ b/common.h
@@ -78,6 +78,7 @@ struct vkcube {
    VkDeviceMemory mem;
    VkBuffer buffer;
    VkDescriptorSet descriptor_set;
+   VkSemaphore semaphore;
    VkFence fence;
    VkCommandPool cmd_pool;
 

--- a/cube.c
+++ b/cube.c
@@ -169,6 +169,11 @@ init_cube(struct vkcube *vc)
                 .minDepth = 0,
                 .maxDepth = 1,
             },
+            .scissorCount = 1,
+            .pScissors = &(VkRect2D) {
+               .offset = { 0, 0 },
+               .extent = { vc->width, vc->height },
+            },
          },
 
          .pRasterizationState = &(VkPipelineRasterizationStateCreateInfo) {

--- a/cube.c
+++ b/cube.c
@@ -492,8 +492,13 @@ render_cube(struct vkcube *vc, struct vkcube_buffer *b)
    vkQueueSubmit(vc->queue, 1,
       &(VkSubmitInfo) {
          .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+         .waitSemaphoreCount = 1,
+         .pWaitSemaphores = &vc->semaphore,
+         .pWaitDstStageMask = (VkPipelineStageFlags []) {
+            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+         },
          .commandBufferCount = 1,
-         &cmd_buffer,
+         .pCommandBuffers = &cmd_buffer,
       }, vc->fence);
 
    vkWaitForFences(vc->device, 1, (VkFence[]) { vc->fence }, true, INT64_MAX);

--- a/cube.c
+++ b/cube.c
@@ -336,7 +336,8 @@ init_cube(struct vkcube *vc)
                   &(VkBufferCreateInfo) {
                      .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
                      .size = mem_size,
-                     .usage = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
+                     .usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT |
+                              VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
                      .flags = 0
                   },
                   NULL,

--- a/cube.c
+++ b/cube.c
@@ -176,7 +176,8 @@ init_cube(struct vkcube *vc)
             .rasterizerDiscardEnable = false,
             .polygonMode = VK_POLYGON_MODE_FILL,
             .cullMode = VK_CULL_MODE_BACK_BIT,
-            .frontFace = VK_FRONT_FACE_CLOCKWISE
+            .frontFace = VK_FRONT_FACE_CLOCKWISE,
+            .lineWidth = 1.0f,
          },
 
          .pMultisampleState = &(VkPipelineMultisampleStateCreateInfo) {

--- a/cube.c
+++ b/cube.c
@@ -159,6 +159,7 @@ init_cube(struct vkcube *vc)
          },
 
          .pViewportState = &(VkPipelineViewportStateCreateInfo) {
+            .sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO,
             .viewportCount = 1,
             .pViewports = &(VkViewport) {
                 .x = 0,
@@ -179,9 +180,12 @@ init_cube(struct vkcube *vc)
          },
 
          .pMultisampleState = &(VkPipelineMultisampleStateCreateInfo) {
+            .sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
             .rasterizationSamples = 1,
          },
-         .pDepthStencilState = &(VkPipelineDepthStencilStateCreateInfo) {},
+         .pDepthStencilState = &(VkPipelineDepthStencilStateCreateInfo) {
+            .sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO
+         },
 
          .pColorBlendState = &(VkPipelineColorBlendStateCreateInfo) {
             .sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,

--- a/cube.c
+++ b/cube.c
@@ -503,6 +503,7 @@ render_cube(struct vkcube *vc, struct vkcube_buffer *b)
       }, vc->fence);
 
    vkWaitForFences(vc->device, 1, (VkFence[]) { vc->fence }, true, INT64_MAX);
+   vkResetFences(vc->device, 1, &vc->fence);
 
    vkResetCommandPool(vc->device, vc->cmd_pool, 0);
 }

--- a/main.c
+++ b/main.c
@@ -942,7 +942,7 @@ init_wayland(struct vkcube *vc)
          .queueFamilyIndexCount = 1,
          .pQueueFamilyIndices = (uint32_t[]) { 0 },
          .preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
-         .compositeAlpha = VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR,
+         .compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
          .presentMode = VK_PRESENT_MODE_MAILBOX_KHR,
       }, NULL, &vc->swap_chain);
 

--- a/main.c
+++ b/main.c
@@ -189,6 +189,13 @@ init_vk(struct vkcube *vc, const char *extension)
                        },
                        NULL,
                        &vc->cmd_pool);
+
+   vkCreateSemaphore(vc->device,
+                     &(VkSemaphoreCreateInfo) {
+                        .sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
+                     },
+                     NULL,
+                     &vc->semaphore);
 }
 
 static void
@@ -766,7 +773,7 @@ mainloop_xcb(struct vkcube *vc)
 
          uint32_t index;
          vkAcquireNextImageKHR(vc->device, vc->swap_chain, 60,
-                               VK_NULL_HANDLE, VK_NULL_HANDLE, &index);
+                               vc->semaphore, VK_NULL_HANDLE, &index);
 
          vc->model.render(vc, &vc->buffers[index]);
 
@@ -972,7 +979,7 @@ mainloop_wayland(struct vkcube *vc)
    while (1) {
       uint32_t index;
       result = vkAcquireNextImageKHR(vc->device, vc->swap_chain, 60,
-                                     VK_NULL_HANDLE, VK_NULL_HANDLE, &index);
+                                     vc->semaphore, VK_NULL_HANDLE, &index);
       if (result != VK_SUCCESS)
          return;
 

--- a/main.c
+++ b/main.c
@@ -209,7 +209,7 @@ init_buffer(struct vkcube *vc, struct vkcube_buffer *b)
                         .subresourceRange = {
                            .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
                            .baseMipLevel = 0,
-                           .levelCount = 0,
+                           .levelCount = 1,
                            .baseArrayLayer = 0,
                            .layerCount = 1,
                         },

--- a/main.c
+++ b/main.c
@@ -108,7 +108,11 @@ init_vk(struct vkcube *vc, const char *extension)
                         .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
                         .queueFamilyIndex = 0,
                         .queueCount = 1,
-                     }
+                     },
+                     .enabledExtensionCount = 1,
+                     .ppEnabledExtensionNames = (const char * const []) {
+                        VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+                     },
                   },
                   NULL,
                   &vc->device);

--- a/main.c
+++ b/main.c
@@ -644,6 +644,10 @@ init_xcb(struct vkcube *vc)
 static void
 alloc_buffers_xcb(struct vkcube *vc)
 {
+   VkSurfaceCapabilitiesKHR surface_caps;
+   vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vc->physical_device, vc->surface,
+                                             &surface_caps);
+
    VkBool32 supported;
    vkGetPhysicalDeviceSurfaceSupportKHR(vc->physical_device, 0, vc->surface,
                                         &supported);
@@ -914,6 +918,10 @@ init_wayland(struct vkcube *vc)
    }
 
    assert(format != VK_FORMAT_UNDEFINED);
+
+   VkSurfaceCapabilitiesKHR surface_caps;
+   vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vc->physical_device, wsi_surface,
+                                             &surface_caps);
 
    VkBool32 supported;
    vkGetPhysicalDeviceSurfaceSupportKHR(vc->physical_device, 0, wsi_surface,

--- a/main.c
+++ b/main.c
@@ -117,6 +117,7 @@ init_vk(struct vkcube *vc, const char *extension)
                         .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
                         .queueFamilyIndex = 0,
                         .queueCount = 1,
+                        .pQueuePriorities = (float []) { 1.0f },
                      },
                      .enabledExtensionCount = 1,
                      .ppEnabledExtensionNames = (const char * const []) {

--- a/main.c
+++ b/main.c
@@ -664,6 +664,21 @@ alloc_buffers_xcb(struct vkcube *vc)
                                         &supported);
    assert(supported);
 
+   uint32_t count;
+   vkGetPhysicalDeviceSurfacePresentModesKHR(vc->physical_device, vc->surface,
+                                             &count, NULL);
+   VkPresentModeKHR present_modes[count];
+   vkGetPhysicalDeviceSurfacePresentModesKHR(vc->physical_device, vc->surface,
+                                             &count, present_modes);
+   int i;
+   VkPresentModeKHR present_mode = VK_PRESENT_MODE_MAILBOX_KHR;
+   for (i = 0; i < count; i++) {
+      if (present_modes[i] == VK_PRESENT_MODE_FIFO_KHR) {
+         present_mode = VK_PRESENT_MODE_FIFO_KHR;
+         break;
+      }
+   }
+
    vkCreateSwapchainKHR(vc->device,
       &(VkSwapchainCreateInfoKHR) {
          .sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR,
@@ -679,7 +694,7 @@ alloc_buffers_xcb(struct vkcube *vc)
          .pQueueFamilyIndices = (uint32_t[]) { 0 },
          .preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
          .compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
-         .presentMode = VK_PRESENT_MODE_MAILBOX_KHR,
+         .presentMode = present_mode,
       }, NULL, &vc->swap_chain);
 
    vkGetSwapchainImagesKHR(vc->device, vc->swap_chain,

--- a/main.c
+++ b/main.c
@@ -105,6 +105,7 @@ init_vk(struct vkcube *vc, const char *extension)
                      .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
                      .queueCreateInfoCount = 1,
                      .pQueueCreateInfos = &(VkDeviceQueueCreateInfo) {
+                        .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
                         .queueFamilyIndex = 0,
                         .queueCount = 1,
                      }

--- a/main.c
+++ b/main.c
@@ -220,6 +220,7 @@ init_buffer(struct vkcube *vc, struct vkcube_buffer *b)
    vkCreateFramebuffer(vc->device,
                        &(VkFramebufferCreateInfo) {
                           .sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
+                          .renderPass = vc->render_pass,
                           .attachmentCount = 1,
                           .pAttachments = &b->view,
                           .width = vc->width,

--- a/main.c
+++ b/main.c
@@ -644,6 +644,11 @@ init_xcb(struct vkcube *vc)
 static void
 alloc_buffers_xcb(struct vkcube *vc)
 {
+   VkBool32 supported;
+   vkGetPhysicalDeviceSurfaceSupportKHR(vc->physical_device, 0, vc->surface,
+                                        &supported);
+   assert(supported);
+
    vkCreateSwapchainKHR(vc->device,
       &(VkSwapchainCreateInfoKHR) {
          .sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR,
@@ -909,6 +914,11 @@ init_wayland(struct vkcube *vc)
    }
 
    assert(format != VK_FORMAT_UNDEFINED);
+
+   VkBool32 supported;
+   vkGetPhysicalDeviceSurfaceSupportKHR(vc->physical_device, 0, wsi_surface,
+                                        &supported);
+   assert(supported);
 
    vkCreateSwapchainKHR(vc->device,
       &(VkSwapchainCreateInfoKHR) {

--- a/main.c
+++ b/main.c
@@ -103,6 +103,12 @@ init_vk(struct vkcube *vc, const char *extension)
    printf("vendor id %04x, device name %s\n",
           properties.vendorID, properties.deviceName);
 
+   vkGetPhysicalDeviceQueueFamilyProperties(vc->physical_device, &count, NULL);
+   assert(count > 0);
+   VkQueueFamilyProperties props[count];
+   vkGetPhysicalDeviceQueueFamilyProperties(vc->physical_device, &count, props);
+   assert(props[0].queueFlags & VK_QUEUE_GRAPHICS_BIT);
+
    vkCreateDevice(vc->physical_device,
                   &(VkDeviceCreateInfo) {
                      .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,

--- a/main.c
+++ b/main.c
@@ -135,7 +135,7 @@ init_vk(struct vkcube *vc, const char *extension)
          .attachmentCount = 1,
          .pAttachments = (VkAttachmentDescription[]) {
             {
-               .format = VK_FORMAT_R8G8B8A8_SRGB,
+               .format = VK_FORMAT_B8G8R8A8_SRGB,
                .samples = 1,
                .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
                .storeOp = VK_ATTACHMENT_STORE_OP_STORE,

--- a/main.c
+++ b/main.c
@@ -91,8 +91,11 @@ init_vk(struct vkcube *vc, const char *extension)
       NULL,
       &vc->instance);
 
-   uint32_t count = 1;
-   vkEnumeratePhysicalDevices(vc->instance, &count, &vc->physical_device);
+   uint32_t count;
+   vkEnumeratePhysicalDevices(vc->instance, &count, NULL);
+   VkPhysicalDevice pd[count];
+   vkEnumeratePhysicalDevices(vc->instance, &count, pd);
+   vc->physical_device = pd[0];
    printf("%d physical devices\n", count);
 
    VkPhysicalDeviceProperties properties;

--- a/main.c
+++ b/main.c
@@ -139,8 +139,8 @@ init_vk(struct vkcube *vc, const char *extension)
                .samples = 1,
                .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
                .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
-               .initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-               .finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+               .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+               .finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
             }
          },
          .subpassCount = 1,

--- a/main.c
+++ b/main.c
@@ -647,6 +647,8 @@ alloc_buffers_xcb(struct vkcube *vc)
    VkSurfaceCapabilitiesKHR surface_caps;
    vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vc->physical_device, vc->surface,
                                              &surface_caps);
+   assert(surface_caps.supportedCompositeAlpha &
+          VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR);
 
    VkBool32 supported;
    vkGetPhysicalDeviceSurfaceSupportKHR(vc->physical_device, 0, vc->surface,
@@ -667,7 +669,7 @@ alloc_buffers_xcb(struct vkcube *vc)
          .queueFamilyIndexCount = 1,
          .pQueueFamilyIndices = (uint32_t[]) { 0 },
          .preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
-         .compositeAlpha = VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR,
+         .compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
          .presentMode = VK_PRESENT_MODE_MAILBOX_KHR,
       }, NULL, &vc->swap_chain);
 


### PR DESCRIPTION
I have run vkcube with the VK_LAYER_LUNARG_standard_validation layer enabled. It complained about a few issues that these patches should address.
