### PR TITLE
Fixes and cmdline options

### DIFF
--- a/common.h
+++ b/common.h
@@ -104,3 +104,9 @@ struct vkcube {
 void noreturn failv(const char *format, va_list args);
 void noreturn fail(const char *format, ...) printflike(1, 2) ;
 void fail_if(int cond, const char *format, ...) printflike(2, 3);
+
+static inline bool
+streq(const char *a, const char *b)
+{
+   return strcmp(a, b) == 0;
+}

--- a/common.h
+++ b/common.h
@@ -1,3 +1,5 @@
+#include <stdarg.h>
+#include <stdnoreturn.h>
 #include <sys/time.h>
 #include <stdbool.h>
 #include <string.h>
@@ -21,6 +23,8 @@
 #include <gbm.h>
 
 #include "esUtil.h"
+
+#define printflike(a, b) __attribute__((format(printf, (a), (b))))
 
 #define MAX_NUM_IMAGES 4
 
@@ -96,3 +100,7 @@ struct vkcube {
    uint32_t image_count;
    int current;
 };
+
+void noreturn failv(const char *format, va_list args);
+void noreturn fail(const char *format, ...) printflike(1, 2) ;
+void fail_if(int cond, const char *format, ...) printflike(2, 3);

--- a/cube.c
+++ b/cube.c
@@ -42,6 +42,8 @@ static char fs_spirv_source[] = {
 static void
 init_cube(struct vkcube *vc)
 {
+   VkResult r;
+
    VkDescriptorSetLayout set_layout;
    vkCreateDescriptorSetLayout(vc->device,
                                &(VkDescriptorSetLayoutCreateInfo) {
@@ -324,7 +326,9 @@ init_cube(struct vkcube *vc)
                     NULL,
                     &vc->mem);
 
-   vkMapMemory(vc->device, vc->mem, 0, mem_size, 0, &vc->map);
+   r = vkMapMemory(vc->device, vc->mem, 0, mem_size, 0, &vc->map);
+   if (r != VK_SUCCESS)
+      fail("vkMapMemory failed");
    memcpy(vc->map + vc->vertex_offset, vVertices, sizeof(vVertices));
    memcpy(vc->map + vc->colors_offset, vColors, sizeof(vColors));
    memcpy(vc->map + vc->normals_offset, vNormals, sizeof(vNormals));

--- a/main.c
+++ b/main.c
@@ -70,6 +70,7 @@ fail_if(int cond, const char *format, ...)
    va_start(args, format);
    vfprintf(stderr, format, args);
    va_end(args);
+   fprintf(stderr, "\n");
 
    exit(1);
 }
@@ -744,7 +745,7 @@ init_xcb(struct vkcube *vc)
    if (!vkGetPhysicalDeviceXcbPresentationSupportKHR(vc->physical_device, 0,
                                                      vc->xcb.conn,
                                                      iter.data->root_visual)) {
-      fprintf(stderr, "Vulkan not supported on given X window");
+      fprintf(stderr, "Vulkan not supported on given X window\n");
       abort();
    }
 
@@ -1058,7 +1059,7 @@ init_wayland(struct vkcube *vc)
 
    if (!get_wayland_presentation_support(vc->physical_device, 0,
                                          vc->wl.display)) {
-      fprintf(stderr, "Vulkan not supported on given Wayland surface");
+      fprintf(stderr, "Vulkan not supported on given Wayland surface\n");
       abort();
    }
 

--- a/main.c
+++ b/main.c
@@ -39,8 +39,6 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <stdarg.h>
-#include <stdnoreturn.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
@@ -60,12 +58,10 @@
 
 #include "common.h"
 
-#define printflike(a, b) __attribute__((format(printf, (a), (b))))
-
 static bool arg_headless = false;
 static const char *arg_out_file = "./cube.png";
 
-static void noreturn
+void noreturn
 failv(const char *format, va_list args)
 {
    vfprintf(stderr, format, args);
@@ -73,7 +69,7 @@ failv(const char *format, va_list args)
    exit(1);
 }
 
-static void printflike(1,2) noreturn
+void printflike(1,2) noreturn
 fail(const char *format, ...)
 {
    va_list args;
@@ -83,7 +79,7 @@ fail(const char *format, ...)
    va_end(args);
 }
 
-static void printflike(2, 3)
+void printflike(2, 3)
 fail_if(int cond, const char *format, ...)
 {
    va_list args;

--- a/main.c
+++ b/main.c
@@ -62,6 +62,8 @@
 
 #define printflike(a, b) __attribute__((format(printf, (a), (b))))
 
+static bool arg_headless = false;
+
 static void noreturn
 failv(const char *format, va_list args)
 {
@@ -1136,10 +1138,37 @@ mainloop_wayland(struct vkcube *vc)
 
 extern struct model cube_model;
 
+static void
+print_usage(FILE *f)
+{
+   const char *usage =
+      "usage: vkcube [-n]\n"
+      "\n"
+      "  -n  Don't initialize vt or kms, run headless.\n"
+      ;
+
+   fprintf(f, "%s", usage);
+}
+
+static void
+parse_args(int argc, char *argv[])
+{
+   if (argc <= 1)
+      return;
+
+   if (strcmp(argv[1], "-n") == 0) {
+      arg_headless = true;
+   } else {
+      print_usage(stderr);
+      exit(1);
+   }
+}
+
 int main(int argc, char *argv[])
 {
    struct vkcube vc;
-   bool headless;
+
+   parse_args(argc, argv);
 
    vc.model = cube_model;
    vc.gbm_device = NULL;
@@ -1149,17 +1178,7 @@ int main(int argc, char *argv[])
    vc.height = 768;
    gettimeofday(&vc.start_tv, NULL);
 
-   if (argc > 1) {
-      if (strcmp(argv[1], "-n") == 0) {
-         headless = true;
-      } else {
-         fprintf(stderr, "usage: vkcube [-n]\n\n"
-		 "  -n  Don't initialize vt or kms, run headless.\n");
-	 exit(1);
-      }
-   }
-
-   if (headless) {
+   if (arg_headless) {
       init_headless(&vc);
    } else {
       init_wayland(&vc);

--- a/main.c
+++ b/main.c
@@ -59,7 +59,9 @@
 
 #include "common.h"
 
-static void
+#define printflike(a, b) __attribute__((format(printf, (a), (b))))
+
+static void printflike(2, 3)
 fail_if(int cond, const char *format, ...)
 {
    va_list args;

--- a/main.c
+++ b/main.c
@@ -1236,6 +1236,9 @@ int main(int argc, char *argv[])
          init_xcb(&vc);
          if (vc.xcb.window == XCB_NONE) {
             init_kms(&vc);
+            if (vc.gbm_device == NULL) {
+               init_headless(&vc);
+            }
          }
       }
    }


### PR DESCRIPTION
```
Shortlog below. The commits that matter most are the ones that add
new cmdline options, starred below. Without them, vkcube is nearly
useless for me. It doesn't run in my test environment.

Chad Versace (12):
      Add missing newline to error messages
      Add format attribute to fail_if()
      Add a fail() func as a companion to fail_if()
      Move argument parsing out of main()
    * Add option -o <file> for the output PNG
      Declare fail*() functions to common.h
      Check vkMapMemory for failure
      If init_kms() fails, fallback to init_headless()
      Add a streq() function
      Make init funcs return -1 on failure
      Explicitly track the display mode
    * Add option -m to select display mode

 common.h |  14 +++++++++++++
 cube.c   |   6 +++++-
 main.c   | 298 ++++++...

```