### PR TITLE
KMS: Use correct DRM event context version

### DIFF
--- a/main.c
+++ b/main.c
@@ -572,7 +572,7 @@ mainloop_vt(struct vkcube *vc)
    pfd[1].events = POLLIN;
 
    drmEventContext evctx = {
-      .version = DRM_EVENT_CONTEXT_VERSION,
+      .version = 2,
       .page_flip_handler = page_flip_handler,
    };
 


### PR DESCRIPTION
DRM_EVENT_CONTEXT_VERSION is the latest context version supported by
whatever version of libdrm is present. vkcube was blindly asserting
it supported whatever version that may be, even if it actually didn't.

With libdrm 2.4.78, setting a higher context version than 2 will attempt
to call the page_flip_handler2 vfunc if it was non-NULL, which being a
random chunk of stack memory, it might well have been.

Set the version as 2, which should be bumped only with the appropriate
version checks.

Signed-off-by: Daniel Stone <daniels@collabora.com>