### PR TITLE
Don't stomp user-provided CFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,15 +1,15 @@
-CPPFLAGS =					\
+AM_CPPFLAGS =					\
 	$(MESA_CPPFLAGS)			\
 	-D_POSIX_C_SOURCE=200809L
 
 common_CFLAGS = -Wall -O0 -g3
 
-CFLAGS = -std=c11				\
+AM_CFLAGS = -std=c11				\
 	 $(common_CFLAGS)			\
 	-Werror=implicit-function-declaration	\
 	-Werror=missing-prototypes
 
-CXXFLAGS = -std=c++11 $(common_CFLAGS)
+AM_CXXFLAGS = -std=c++11 $(common_CFLAGS)
 
 noinst_PROGRAMS = vkcube
 
@@ -32,5 +32,5 @@ vkcube_SOURCES =				\
 
 CLEANFILES = $(BUILT_SOURCES)
 
-vkcube_CFLAGS = $(CFLAGS) $(MINIGBM_CPPFLAGS) $(LIBDRM_CFLAGS) $(WAYLAND_CFLAGS)  $(LIBPNG_CFLAGS)
+vkcube_CFLAGS = $(AM_CFLAGS) $(MINIGBM_CPPFLAGS) $(LIBDRM_CFLAGS) $(WAYLAND_CFLAGS)  $(LIBPNG_CFLAGS)
 vkcube_LDADD = $(MINIGBM_LDFLAGS) $(MESA_LDFLAGS) $(LIBDRM_LIBS) $(WAYLAND_LIBS)  $(LIBPNG_LIBS) -lgbm -lm -lvulkan -lxcb


### PR DESCRIPTION
AM_CFLAGS is the generally-accepted variable for CFLAGS internal to the
build system. CFLAGS is a user-only variable which can be overridden at
./configure or build time.

Signed-off-by: Daniel Stone <daniels@collabora.com>