### PR TITLE
Use the right memory type for the vertex buffer

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,5 @@
 AM_CPPFLAGS =					\
-	$(MESA_CPPFLAGS)			\
-	-D_POSIX_C_SOURCE=200809L
+	$(MESA_CPPFLAGS)
 
 common_CFLAGS = -Wall -O0 -g3
 

--- a/common.h
+++ b/common.h
@@ -3,6 +3,7 @@
 #include <sys/time.h>
 #include <stdbool.h>
 #include <string.h>
+#include <strings.h>
 
 #include <xf86drm.h>
 #include <xf86drmMode.h>


### PR DESCRIPTION
Since [39adea9330376](https://cgit.freedesktop.org/mesa/mesa/commit/?id=39adea9330376) in Mesa the Intel driver no longer supports vertices in the first memory type so vkcube is currently hitting an assert.