### PR TITLE
Allocate the buffer using host visible memory.

### DIFF
--- a/common.h
+++ b/common.h
@@ -78,6 +78,7 @@ struct vkcube {
 
    VkInstance instance;
    VkPhysicalDevice physical_device;
+   VkPhysicalDeviceMemoryProperties memory_properties;
    VkDevice device;
    VkRenderPass render_pass;
    VkQueue queue;

--- a/main.c
+++ b/main.c
@@ -145,6 +145,8 @@ init_vk(struct vkcube *vc, const char *extension)
    printf("vendor id %04x, device name %s\n",
           properties.vendorID, properties.deviceName);
 
+   vkGetPhysicalDeviceMemoryProperties(vc->physical_device, &vc->memory_properties);
+
    vkGetPhysicalDeviceQueueFamilyProperties(vc->physical_device, &count, NULL);
    assert(count > 0);
    VkQueueFamilyProperties props[count];


### PR DESCRIPTION
As well as coherent, since we don't do any flushes on the CPU.

Fixes a crash on startup with radv, as the first memory type is
not host visible.