### PR TITLE
wayland: wait for idle queue before rerendering

### DIFF
--- a/main.c
+++ b/main.c
@@ -1194,6 +1194,8 @@ mainloop_wayland(struct vkcube *vc)
          });
       if (result != VK_SUCCESS)
          return;
+
+      vkQueueWaitIdle(vc->queue);
    }
 }
 


### PR DESCRIPTION
Debug layer issue  :

    DS(ERROR / SPEC): object: 0x560b659fb8a0 type: 6 msgNum: 847249488
    - Attempt to reset command pool with command buffer
    (0x560b659fb8a0) which is in use. The spec valid usage text states
    'All VkCommandBuffer objects allocated from commandPool must not
    be in the pending state'
    (https://www.khronos.org/registry/vulkan/specs/1.0/html/vkspec.html#VUID-vkResetCommandPool-commandPool-00040)

Triggered a hang on my machine : https://bugs.freedesktop.org/show_bug.cgi?id=105930