### PR TITLE
Validator fixes

### DIFF
--- a/common.h
+++ b/common.h
@@ -34,6 +34,8 @@ struct vkcube_buffer {
    VkImage image;
    VkImageView view;
    VkFramebuffer framebuffer;
+   VkFence fence;
+
    uint32_t fb;
    uint32_t stride;
 };
@@ -88,7 +90,6 @@ struct vkcube {
    VkBuffer buffer;
    VkDescriptorSet descriptor_set;
    VkSemaphore semaphore;
-   VkFence fence;
    VkCommandPool cmd_pool;
 
    void *map;

--- a/common.h
+++ b/common.h
@@ -35,6 +35,7 @@ struct vkcube_buffer {
    VkImageView view;
    VkFramebuffer framebuffer;
    VkFence fence;
+   VkCommandBuffer cmd_buffer;
 
    uint32_t fb;
    uint32_t stride;

--- a/cube.c
+++ b/cube.c
@@ -442,25 +442,13 @@ render_cube(struct vkcube *vc, struct vkcube_buffer *b)
    vkWaitForFences(vc->device, 1, &b->fence, VK_TRUE, UINT64_MAX);
    vkResetFences(vc->device, 1, &b->fence);
 
-   vkResetCommandPool(vc->device, vc->cmd_pool, 0);
-
-   VkCommandBuffer cmd_buffer;
-   vkAllocateCommandBuffers(vc->device,
-      &(VkCommandBufferAllocateInfo) {
-         .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
-         .commandPool = vc->cmd_pool,
-         .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
-         .commandBufferCount = 1,
-      },
-      &cmd_buffer);
-
-   vkBeginCommandBuffer(cmd_buffer,
+   vkBeginCommandBuffer(b->cmd_buffer,
                         &(VkCommandBufferBeginInfo) {
                            .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
                            .flags = 0
                         });
 
-   vkCmdBeginRenderPass(cmd_buffer,
+   vkCmdBeginRenderPass(b->cmd_buffer,
                         &(VkRenderPassBeginInfo) {
                            .sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
                            .renderPass = vc->render_pass,
@@ -473,7 +461,7 @@ render_cube(struct vkcube *vc, struct vkcube_buffer *b)
                         },
                         VK_SUBPASS_CONTENTS_INLINE);
 
-   vkCmdBindVertexBuffers(cmd_buffer, 0, 3,
+   vkCmdBindVertexBuffers(b->cmd_buffer, 0, 3,
                           (VkBuffer[]) {
                              vc->buffer,
                              vc->buffer,
@@ -485,9 +473,9 @@ render_cube(struct vkcube *vc, struct vkcube_buffer *b)
                              vc->normals_offset
                            });
 
-   vkCmdBindPipeline(cmd_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, vc->pipeline);
+   vkCmdBindPipeline(b->cmd_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, vc->pipeline);
 
-   vkCmdBindDescriptorSets(cmd_buffer,
+   vkCmdBindDescriptorSets(b->cmd_buffer,
                            VK_PIPELINE_BIND_POINT_GRAPHICS,
                            vc->pipeline_layout,
                            0, 1,
@@ -501,24 +489,24 @@ render_cube(struct vkcube *vc, struct vkcube_buffer *b)
       .minDepth = 0,
       .maxDepth = 1,
    };
-   vkCmdSetViewport(cmd_buffer, 0, 1, &viewport);
+   vkCmdSetViewport(b->cmd_buffer, 0, 1, &viewport);
 
    const VkRect2D scissor = {
       .offset = { 0, 0 },
       .extent = { vc->width, vc->height },
    };
-   vkCmdSetScissor(cmd_buffer, 0, 1, &scissor);
+   vkCmdSetScissor(b->cmd_buffer, 0, 1, &scissor);
 
-   vkCmdDraw(cmd_buffer, 4, 1, 0, 0);
-   vkCmdDraw(cmd_buffer, 4, 1, 4, 0);
-   vkCmdDraw(cmd_buffer, 4, 1, 8, 0);
-   vkCmdDraw(cmd_buffer, 4, 1, 12, 0);
-   vkCmdDraw(cmd_buffer, 4, 1, 16, 0);
-   vkCmdDraw(cmd_buffer, 4, 1, 20, 0);
+   vkCmdDraw(b->cmd_buffer, 4, 1, 0, 0);
+   vkCmdDraw(b->cmd_buffer, 4, 1, 4, 0);
+   vkCmdDraw(b->cmd_buffer, 4, 1, 8, 0);
+   vkCmdDraw(b->cmd_buffer, 4, 1, 12, 0);
+   vkCmdDraw(b->cmd_buffer, 4, 1, 16, 0);
+   vkCmdDraw(b->cmd_buffer, 4, 1, 20, 0);
 
-   vkCmdEndRenderPass(cmd_buffer);
+   vkCmdEndRenderPass(b->cmd_buffer);
 
-   vkEndCommandBuffer(cmd_buffer);
+   vkEndCommandBuffer(b->cmd_buffer);
 
    vkQueueSubmit(vc->queue, 1,
       &(VkSubmitInfo) {
@@ -529,7 +517,7 @@ render_cube(struct vkcube *vc, struct vkcube_buffer *b)
             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
          },
          .commandBufferCount = 1,
-         .pCommandBuffers = &cmd_buffer,
+         .pCommandBuffers = &b->cmd_buffer,
       }, b->fence);
 }
 

--- a/cube.c
+++ b/cube.c
@@ -527,7 +527,7 @@ render_cube(struct vkcube *vc, struct vkcube_buffer *b)
          },
          .commandBufferCount = 1,
          .pCommandBuffers = &cmd_buffer,
-      }, vc->fence);
+      }, b->fence);
 }
 
 struct model cube_model = {

--- a/cube.c
+++ b/cube.c
@@ -439,6 +439,9 @@ render_cube(struct vkcube *vc, struct vkcube_buffer *b)
 
    memcpy(vc->map, &ubo, sizeof(ubo));
 
+   vkWaitForFences(vc->device, 1, &b->fence, VK_TRUE, UINT64_MAX);
+   vkResetFences(vc->device, 1, &b->fence);
+
    vkResetCommandPool(vc->device, vc->cmd_pool, 0);
 
    VkCommandBuffer cmd_buffer;

--- a/main.c
+++ b/main.c
@@ -726,6 +726,7 @@ create_swapchain(struct vkcube *vc)
    vkGetSwapchainImagesKHR(vc->device, vc->swap_chain,
                            &vc->image_count, swap_chain_images);
 
+   assert(vc->image_count <= MAX_NUM_IMAGES);
    for (uint32_t i = 0; i < vc->image_count; i++) {
       vc->buffers[i].image = swap_chain_images[i];
       init_buffer(vc, &vc->buffers[i]);
@@ -918,6 +919,7 @@ mainloop_xcb(struct vkcube *vc)
          vkAcquireNextImageKHR(vc->device, vc->swap_chain, 60,
                                vc->semaphore, VK_NULL_HANDLE, &index);
 
+         assert(index <= MAX_NUM_IMAGES);
          vc->model.render(vc, &vc->buffers[index]);
 
          VkResult result;
@@ -1182,6 +1184,7 @@ mainloop_wayland(struct vkcube *vc)
       if (result != VK_SUCCESS)
          return;
 
+      assert(index <= MAX_NUM_IMAGES);
       vc->model.render(vc, &vc->buffers[index]);
 
       vkQueuePresentKHR(vc->queue,

--- a/main.c
+++ b/main.c
@@ -710,11 +710,24 @@ create_swapchain(struct vkcube *vc)
       }
    }
 
+   uint32_t minImageCount = 2;
+   if (minImageCount < surface_caps.minImageCount) {
+      if (surface_caps.minImageCount > MAX_NUM_IMAGES)
+          fail("surface_caps.minImageCount is too large (is: %d, max: %d)",
+               surface_caps.minImageCount, MAX_NUM_IMAGES);
+      minImageCount = surface_caps.minImageCount;
+   }
+
+   if (surface_caps.maxImageCount > 0 &&
+       minImageCount > surface_caps.maxImageCount) {
+      minImageCount = surface_caps.maxImageCount;
+   }
+
    vkCreateSwapchainKHR(vc->device,
       &(VkSwapchainCreateInfoKHR) {
          .sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR,
          .surface = vc->surface,
-         .minImageCount = 2,
+         .minImageCount = minImageCount,
          .imageFormat = vc->image_format,
          .imageColorSpace = VK_COLORSPACE_SRGB_NONLINEAR_KHR,
          .imageExtent = { vc->width, vc->height },

--- a/main.c
+++ b/main.c
@@ -221,14 +221,6 @@ init_vk_objects(struct vkcube *vc)
 
    vc->model.init(vc);
 
-   vkCreateFence(vc->device,
-                 &(VkFenceCreateInfo) {
-                    .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
-                    .flags = 0
-                 },
-                 NULL,
-                 &vc->fence);
-
    vkCreateCommandPool(vc->device,
                        &(const VkCommandPoolCreateInfo) {
                           .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
@@ -284,6 +276,14 @@ init_buffer(struct vkcube *vc, struct vkcube_buffer *b)
                        },
                        NULL,
                        &b->framebuffer);
+
+   vkCreateFence(vc->device,
+                 &(VkFenceCreateInfo) {
+                    .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
+                    .flags = 0
+                 },
+                 NULL,
+                 &b->fence);
 }
 
 /* Headless code - write one frame to png */

--- a/main.c
+++ b/main.c
@@ -280,7 +280,7 @@ init_buffer(struct vkcube *vc, struct vkcube_buffer *b)
    vkCreateFence(vc->device,
                  &(VkFenceCreateInfo) {
                     .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
-                    .flags = 0
+                    .flags = VK_FENCE_CREATE_SIGNALED_BIT
                  },
                  NULL,
                  &b->fence);

--- a/main.c
+++ b/main.c
@@ -225,7 +225,7 @@ init_vk_objects(struct vkcube *vc)
                        &(const VkCommandPoolCreateInfo) {
                           .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
                           .queueFamilyIndex = 0,
-                          .flags = 0
+                          .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT
                        },
                        NULL,
                        &vc->cmd_pool);
@@ -284,6 +284,15 @@ init_buffer(struct vkcube *vc, struct vkcube_buffer *b)
                  },
                  NULL,
                  &b->fence);
+
+   vkAllocateCommandBuffers(vc->device,
+      &(VkCommandBufferAllocateInfo) {
+         .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+         .commandPool = vc->cmd_pool,
+         .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+         .commandBufferCount = 1,
+      },
+      &b->cmd_buffer);
 }
 
 /* Headless code - write one frame to png */

--- a/main.c
+++ b/main.c
@@ -210,8 +210,8 @@ init_vk_objects(struct vkcube *vc)
                   }
                },
                .pDepthStencilAttachment = NULL,
-               .preserveAttachmentCount = 1,
-               .pPreserveAttachments = (uint32_t []) { 0 },
+               .preserveAttachmentCount = 0,
+               .pPreserveAttachments = NULL,
             }
          },
          .dependencyCount = 0


### PR DESCRIPTION
Here's a patch-series that fix some problems that lead to crashes on some drivers, but luckily the vulkan-validator can spot.

The most important ones are timing-related; we need to take care to tamper with fences and command-buffers currently being used by the GPU. To ensure this, we should create one of these per swap-image instead of reusing a single one.