### PR TITLE
60 nanoseconds may be not enough to acquire next available image.

### DIFF
--- a/main.c
+++ b/main.c
@@ -938,7 +938,7 @@ mainloop_xcb(struct vkcube *vc)
             create_swapchain(vc);
 
          uint32_t index;
-         vkAcquireNextImageKHR(vc->device, vc->swap_chain, 60,
+         vkAcquireNextImageKHR(vc->device, vc->swap_chain, UINT64_MAX,
                                vc->semaphore, VK_NULL_HANDLE, &index);
 
          assert(index <= MAX_NUM_IMAGES);


### PR DESCRIPTION
It is better to use UINT64_MAX. So that, vkAcquireNextImageKHR will not return until an image is acquired from the presentation engine.