### PR TITLE
xcb: flush after sending the message to trigger a repaint.

### DIFF
--- a/main.c
+++ b/main.c
@@ -873,6 +873,7 @@ schedule_xcb_repaint(struct vkcube *vc)
 
    xcb_send_event(vc->xcb.conn, 0, vc->xcb.window,
                   0, (char *) &client_message);
+   xcb_flush(vc->xcb.conn);
 }
 
 static void


### PR DESCRIPTION
Otherwise with fullscreen we only redraw when something causes a flush,
like e.g. a keypress.

extra painful due to the 60ns timeout for acquire.