### PR TITLE
meson: correctly track generator output

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -33,14 +33,14 @@ vkcube_files = files(
 if prog_glslc.found()
   gen = generator(
     prog_glslc,
-    output : '@PLAINNAME@',
-    arguments : [ '@INPUT@', '-mfmt=num', '-o', '@OUTPUT@.spv.h' ]
+    output : '@PLAINNAME@.spv.h',
+    arguments : [ '@INPUT@', '-mfmt=num', '-o', '@OUTPUT@' ]
   )
 else
   gen = generator(
     prog_cp,
-    output : '@PLAINNAME@',
-    arguments : [ '@INPUT@.spv.h.in', '@OUTPUT@.spv.h' ]
+    output : '@PLAINNAME@.spv.h',
+    arguments : [ '@INPUT@.spv.h.in', '@OUTPUT@' ]
   )
 endif
 


### PR DESCRIPTION
Meson uses the output filename to track things like file modification.
The issue was noticed because running `ninja` a couple times in a row would alternatively re-genenerate the spirv headers and re-build vkcube, instead of tracking everything correctly and not have to do anything after the first `ninja` run.