### PR TITLE
add VK_KHR_display support

### DIFF
--- a/common.h
+++ b/common.h
@@ -73,6 +73,10 @@ struct vkcube {
       bool wait_for_configure;
    } wl;
 
+   struct {
+      VkDisplayModeKHR display_mode;
+   } khr;
+
    VkSwapchainKHR swap_chain;
 
    drmModeCrtc *crtc;


### PR DESCRIPTION
To list displays (monitors) :

   ./build/vkcube -m khr
   1 physical devices
   vendor id 8086, device name Intel(R) Iris Pro Graphics 580 (Skylake GT4e)
   display [0]:
      name: monitor
      physical dimensions: 444x278
      physical resolution: 1680x1050
      plane reorder: no
      persistent content: no

To list modes for display 0 :

   ./build/vkcube -m khr -k 0
   1 physical devices
   vendor id 8086, device name Intel(R) Iris Pro Graphics 580 (Skylake GT4e)
   display [0] (monitor) modes:
   mode [0]:
      visible region: 1680x1050
      refresh rate: 59883
   mode [1]:
      visible region: 1280x1024
      refresh rate: 75025
   mode [2]:
      visible region: 1280x1024
      refresh rate: 60020
   mode [3]:
      visible region: 1280x960
      refresh rate: 60000
   ...

Finally to list planes for display 0 in mode 0 :

   ./build/vkcube -m khr -k 0:0
   1 physical devices
   vendor id 8086, device name Intel(R) Iris Pro Graphics 580 (Skylake GT4e)
   display [0] (monitor) plane [0]
      current stack index: 0
      displays supported: 0
      src pos: 0x0 -> 0x0
      src size: 1680x1050 -> 1680x1050
      dst pos: 0x0 -> 0x0
   display [0] (monitor) plane [1]
      current stack index: 0
      displays supported:
      src pos: 0x0 -> 0x0
      src size: 1680x1050 -> 1680x1050
      dst pos: 0x0 -> 0x0
   ...

You can then start the vkcube on the display 0 in mode 0 on plane 0 :

   ./build/vkcube -m khr -k 0:0:0

Signed-off-by: Lionel Landwerlin <lionel.g.landwerlin@intel.com>