### PR TITLE
Make sure the vulkan/vulkan.h header is found

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ dep_gbm = dependency('gbm')
 dep_libpng = dependency('libpng')
 dep_wayland = dependency('wayland-client')
 dep_xcb = dependency('xcb')
-dep_vulkan = dependency('vulkan')
+dep_vulkan = cc.find_library('vulkan', has_headers: ['vulkan/vulkan.h'])
 dep_m = cc.find_library('m', required : false)
 
 cc = meson.get_compiler('c')


### PR DESCRIPTION
Since Archlinux has the `vulkan/vulkan.h` header in a separate package named `vulkan-headers`, the vulkan dependency may be found even without the correct header being present.