### PR TITLE
do not wait for unsignaled semaphore (fix headless mode)

### DIFF
--- a/common.h
+++ b/common.h
@@ -45,7 +45,7 @@ struct vkcube;
 
 struct model {
    void (*init)(struct vkcube *vc);
-   void (*render)(struct vkcube *vc, struct vkcube_buffer *b);
+   void (*render)(struct vkcube *vc, struct vkcube_buffer *b, bool wait_semaphore);
 };
 
 struct vkcube {

--- a/cube.c
+++ b/cube.c
@@ -409,7 +409,7 @@ init_cube(struct vkcube *vc)
 }
 
 static void
-render_cube(struct vkcube *vc, struct vkcube_buffer *b)
+render_cube(struct vkcube *vc, struct vkcube_buffer *b, bool wait_semaphore)
 {
    struct ubo ubo;
    struct timeval tv;
@@ -511,7 +511,8 @@ render_cube(struct vkcube *vc, struct vkcube_buffer *b)
    vkQueueSubmit(vc->queue, 1,
       &(VkSubmitInfo) {
          .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
-         .waitSemaphoreCount = 1,
+         /* headless mode does not signal vc->semaphore */
+         .waitSemaphoreCount = wait_semaphore ? 1 : 0,
          .pWaitSemaphores = &vc->semaphore,
          .pWaitDstStageMask = (VkPipelineStageFlags []) {
             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,

--- a/main.c
+++ b/main.c
@@ -619,7 +619,7 @@ mainloop_vt(struct vkcube *vc)
       if (pfd[1].revents & POLLIN) {
          drmHandleEvent(vc->fd, &evctx);
          b = &vc->buffers[vc->current & 1];
-         vc->model.render(vc, b);
+         vc->model.render(vc, b, false);
 
          ret = drmModePageFlip(vc->fd, vc->crtc->crtc_id, b->fb,
                                DRM_MODE_PAGE_FLIP_EVENT, NULL);
@@ -956,7 +956,7 @@ mainloop_xcb(struct vkcube *vc)
          }
 
          assert(index <= MAX_NUM_IMAGES);
-         vc->model.render(vc, &vc->buffers[index]);
+         vc->model.render(vc, &vc->buffers[index], true);
 
          vkQueuePresentKHR(vc->queue,
              &(VkPresentInfoKHR) {
@@ -1219,7 +1219,7 @@ mainloop_wayland(struct vkcube *vc)
          return;
 
       assert(index <= MAX_NUM_IMAGES);
-      vc->model.render(vc, &vc->buffers[index]);
+      vc->model.render(vc, &vc->buffers[index], true);
 
       vkQueuePresentKHR(vc->queue,
          &(VkPresentInfoKHR) {
@@ -1453,7 +1453,7 @@ mainloop_khr(struct vkcube *vc)
          return;
 
       assert(index <= MAX_NUM_IMAGES);
-      vc->model.render(vc, &vc->buffers[index]);
+      vc->model.render(vc, &vc->buffers[index], true);
 
       vkQueuePresentKHR(vc->queue,
          &(VkPresentInfoKHR) {
@@ -1668,7 +1668,7 @@ mainloop(struct vkcube *vc)
       mainloop_khr(vc);
       break;
    case DISPLAY_MODE_HEADLESS:
-      vc->model.render(vc, &vc->buffers[0]);
+      vc->model.render(vc, &vc->buffers[0], false);
       write_buffer(vc, &vc->buffers[0]);
       break;
    }


### PR DESCRIPTION
Fix this validation error when running "vkcube -n":

The Vulkan spec states: All elements of the pWaitSemaphores member of all
elements of pSubmits must be semaphores that are signaled, or have
semaphore signal operations previously submitted for execution

This fixes headless mode with turnip.