### PR TITLE
Call vkGetDisplayPlaneCapabilitiesKHR() with the loop index

### DIFF
--- a/main.c
+++ b/main.c
@@ -1368,7 +1368,7 @@ init_khr(struct vkcube *vc)
          VkDisplayPlaneCapabilitiesKHR plane_caps;
          vkGetDisplayPlaneCapabilitiesKHR(vc->physical_device,
                                           modes[display_mode_idx].displayMode,
-                                          display_plane_idx,
+                                          i,
                                           &plane_caps);
          fprintf(stdout, "   src pos: %ux%u -> %ux%u\n",
                  plane_caps.minSrcPosition.x,


### PR DESCRIPTION
I might be wrong, but the loop index should be used when calling vkGetDisplayPlaneCapabilitiesKHR()

Nicolas Caramelli