### PR TITLE
headless: wait queue is idle before writing image to disk

### DIFF
--- a/main.c
+++ b/main.c
@@ -1669,6 +1669,7 @@ mainloop(struct vkcube *vc)
       break;
    case DISPLAY_MODE_HEADLESS:
       vc->model.render(vc, &vc->buffers[0], false);
+      vkQueueWaitIdle(vc->queue);
       write_buffer(vc, &vc->buffers[0]);
       break;
    }


### PR DESCRIPTION
I noticed a few times that we were missing some bits of the image...

Signed-off-by: Lionel Landwerlin <lionel.g.landwerlin@intel.com>