### PR TITLE
khr mode: print dst size when listing planes

### DIFF
--- a/main.c
+++ b/main.c
@@ -1385,6 +1385,11 @@ init_khr(struct vkcube *vc)
                  plane_caps.minDstPosition.y,
                  plane_caps.maxDstPosition.x,
                  plane_caps.maxDstPosition.y);
+         fprintf(stdout, "   dst size: %ux%u -> %ux%u\n",
+                 plane_caps.minDstExtent.width,
+                 plane_caps.minDstExtent.height,
+                 plane_caps.maxDstExtent.width,
+                 plane_caps.maxDstExtent.height);
       }
       free(displays);
       free(modes);


### PR DESCRIPTION
Also print the dst size when listing planes for a display.

Nicolas Caramelli