### PR TITLE
Add options to specify width and height

### DIFF
--- a/main.c
+++ b/main.c
@@ -69,6 +69,7 @@ enum display_mode {
 };
 
 static enum display_mode display_mode = DISPLAY_MODE_AUTO;
+static uint32_t width = 1024, height = 768;
 static const char *arg_out_file = "./cube.png";
 static bool protected_chain = false;
 
@@ -1547,6 +1548,10 @@ print_usage(FILE *f)
       "                          \"kms\", \"wayland\", or \"xcb\". This option is\n"
       "                          incompatible with '-n'.\n"
       "\n"
+      "  -w                      Specify width.\n"
+      "\n"
+      "  -h                      Specify height.\n"
+      "\n"
       "  -k <display:mode:plane> Select KHR configuration with 3 number separated\n"
       "                          by the column character. To display the item\n"
       "                          corresponding to those number, just omit the number.\n"
@@ -1585,7 +1590,7 @@ parse_args(int argc, char *argv[])
     * The initial ':' in the optstring makes getopt return ':' when an option
     * is missing a required argument.
     */
-   static const char *optstring = "+:nm:o:k:p";
+   static const char *optstring = "+:nm:w:h:o:k:p";
 
    int opt;
    bool found_arg_headless = false;
@@ -1601,6 +1606,12 @@ parse_args(int argc, char *argv[])
       case 'n':
          found_arg_headless = true;
          display_mode = DISPLAY_MODE_HEADLESS;
+         break;
+      case 'w':
+         width = atoi(optarg);
+         break;
+      case 'h':
+         height = atoi(optarg);
          break;
       case 'k': {
          char config[40], *saveptr, *t;
@@ -1725,8 +1736,8 @@ int main(int argc, char *argv[])
    vc.gbm_device = NULL;
    vc.xcb.window = XCB_NONE;
    vc.wl.surface = NULL;
-   vc.width = 1024;
-   vc.height = 768;
+   vc.width = width;
+   vc.height = height;
    vc.protected = protected_chain;
    gettimeofday(&vc.start_tv, NULL);
 


### PR DESCRIPTION
This change adds -w and -h options to specify width and height when running vkcube.

Nicolas Caramelli