### PR TITLE
Fix present mode selection

### DIFF
--- a/common.h
+++ b/common.h
@@ -26,7 +26,7 @@
 
 #define printflike(a, b) __attribute__((format(printf, (a), (b))))
 
-#define MAX_NUM_IMAGES 4
+#define MAX_NUM_IMAGES 5
 
 struct vkcube_buffer {
    struct gbm_bo *gbm_bo;

--- a/main.c
+++ b/main.c
@@ -732,10 +732,10 @@ create_swapchain(struct vkcube *vc)
    vkGetPhysicalDeviceSurfacePresentModesKHR(vc->physical_device, vc->surface,
                                              &count, present_modes);
    int i;
-   VkPresentModeKHR present_mode = VK_PRESENT_MODE_MAILBOX_KHR;
+   VkPresentModeKHR present_mode = VK_PRESENT_MODE_FIFO_KHR;
    for (i = 0; i < count; i++) {
-      if (present_modes[i] == VK_PRESENT_MODE_FIFO_KHR) {
-         present_mode = VK_PRESENT_MODE_FIFO_KHR;
+      if (present_modes[i] == VK_PRESENT_MODE_MAILBOX_KHR) {
+         present_mode = VK_PRESENT_MODE_MAILBOX_KHR;
          break;
       }
    }


### PR DESCRIPTION
Former implementation effectively always selected
VK_PRESENT_MODE_FIFO_KHR. This is probably not intended.

Intended behaviour is probably selecting
VK_PRESENT_MODE_MAILBOX_KHR over fallback VK_PRESENT_MODE_FIFO_KHR,
which is established with this commit.