### PR TITLE
Wayland fixes

### DIFF
--- a/main.c
+++ b/main.c
@@ -1287,7 +1287,8 @@ mainloop_wayland(struct vkcube *vc)
 
       result = vkAcquireNextImageKHR(vc->device, vc->swap_chain, 60,
                                      vc->semaphore, VK_NULL_HANDLE, &index);
-      if (result == VK_SUBOPTIMAL_KHR) {
+      if (result == VK_SUBOPTIMAL_KHR ||
+          result == VK_ERROR_OUT_OF_DATE_KHR) {
          recreate_swapchain(vc);
          continue;
       } else if (result == VK_NOT_READY ||

--- a/main.c
+++ b/main.c
@@ -1290,6 +1290,9 @@ mainloop_wayland(struct vkcube *vc)
       if (result == VK_SUBOPTIMAL_KHR) {
          recreate_swapchain(vc);
          continue;
+      } else if (result == VK_NOT_READY ||
+                 result == VK_TIMEOUT) {
+         continue;
       } else if (result != VK_SUCCESS) {
          return;
       }


### PR DESCRIPTION
Error handling for `vkAcquireNextImageKHR()` in the Wayland-codepath was a bit willy-nilly. This fixes some of the more common errors.

In particular, failing to handle the `VK_NOT_READY` / `VK_TIMEOUT` errors makes vkcube not work at all for me, because 60ns is a veeeery short timeout, and is extremely likely to make timeouts trigger.