### PR TITLE
Print helpful error message when KMS is not available

### DIFF
--- a/main.c
+++ b/main.c
@@ -674,6 +674,7 @@ mainloop_vt(struct vkcube *vc)
 static int
 init_kms(struct vkcube *vc)
 {
+   fprintf(stderr, "vkcube not built with KMS support (no vulkan_intel.h)\n");
    return -1;
 }
 


### PR DESCRIPTION
init_kms fails without explanation if vkcube is build without the presence of vulkan_intel.h, leading to confusing error message "failed to initialize kms".
Temporary remedy for #46