### PR TITLE
Make KMS support configurable at build time

### DIFF
--- a/common.h
+++ b/common.h
@@ -3,11 +3,14 @@
 #include <sys/time.h>
 #include <stdbool.h>
 #include <string.h>
-#include <strings.h>
 
+#if defined(HAVE_VULKAN_INTEL_H)
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 #include <drm_fourcc.h>
+#include <gbm.h>
+#endif
+
 #include <png.h>
 
 #if defined(ENABLE_XCB)
@@ -24,8 +27,6 @@
 #define VK_PROTOTYPES
 #include <vulkan/vulkan.h>
 
-#include <gbm.h>
-
 #include "esUtil.h"
 
 #define printflike(a, b) __attribute__((format(printf, (a), (b))))
@@ -33,7 +34,10 @@
 #define MAX_NUM_IMAGES 5
 
 struct vkcube_buffer {
+#if defined(HAVE_VULKAN_INTEL_H)
    struct gbm_bo *gbm_bo;
+   uint32_t fb;
+#endif
    VkDeviceMemory mem;
    VkImage image;
    VkImageView view;
@@ -41,7 +45,6 @@ struct vkcube_buffer {
    VkFence fence;
    VkCommandBuffer cmd_buffer;
 
-   uint32_t fb;
    uint32_t stride;
 };
 
@@ -57,8 +60,12 @@ struct vkcube {
 
    bool protected;
 
+#if defined(HAVE_VULKAN_INTEL_H)
    int fd;
+   drmModeCrtc *crtc;
+   drmModeConnector *connector;
    struct gbm_device *gbm_device;
+#endif
 
 #if defined(ENABLE_XCB)
    struct {
@@ -89,8 +96,6 @@ struct vkcube {
 
    VkSwapchainKHR swap_chain;
 
-   drmModeCrtc *crtc;
-   drmModeConnector *connector;
    uint32_t width, height;
 
    VkInstance instance;

--- a/meson.build
+++ b/meson.build
@@ -7,14 +7,15 @@ dep_m = cc.find_library('m', required : false)
 
 dep_vulkan = dependency('vulkan')
 dep_libpng = dependency('libpng')
-dep_libdrm = dependency('libdrm')
-dep_gbm = dependency('gbm')
+dep_libdrm = dependency('libdrm', required : get_option('kms') == 'true')
+dep_gbm = dependency('gbm', required : get_option('kms') == 'true')
 dep_wayland_client = dependency('wayland-client', required : get_option('wayland') == 'true')
 dep_wayland_protocols = dependency('wayland-protocols', version : '>= 1.12', required : get_option('wayland') == 'true')
 dep_xcb = dependency('xcb', required : get_option('xcb') == 'true')
 
 defs = []
-if cc.has_header('vulkan/vulkan_intel.h', dependencies: dep_vulkan)
+if dep_libdrm.found() and dep_gbm.found() and cc.has_header('vulkan/vulkan_intel.h', dependencies: dep_vulkan)
+  message('kms enabled')
   defs += '-DHAVE_VULKAN_INTEL_H'
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
+option('kms', type : 'combo', choices : ['auto', 'true', 'false'], value : 'auto')
 option('xcb', type : 'combo', choices : ['auto', 'true', 'false'], value : 'auto')
 option('wayland', type : 'combo', choices : ['auto', 'true', 'false'], value : 'auto')


### PR DESCRIPTION
As vkcube can run on platforms without gbm, I find it useful to make it configurable at build time, similar to XCB and Wayland.

To do this, the existing HAVE_VULKAN_INTEL_H flag is used.

Note that if init_wayland(vc) failed and XCB was missing, the following message was printed:
	"failed to initialize wayland, falling back to xcb"
instead of:
	"failed to initialize wayland, falling back to kms"

This is now fixed in this PR.